### PR TITLE
Extend cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ pythonhosted/
 tags
 .vscode
 .idea
+.project
+.pydevproject
 
 # Packaging detritus
 *.egg

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 "Nina's Translation Tidy-up Tool"
 
-Note - NTTT will only work on Windows.
+Note - NTTT will work on Windows, macOS and Linux.
 
 ## Install
 
@@ -54,16 +54,28 @@ To bring up full usage information use the `-h`/`--help` option.
 ```bash
 nttt -h
 
-usage: nttt [-h] [-i INPUT] [-o OUTPUT]
+usage: nttt [-h] [-i INPUT] [-o OUTPUT] [-e ENGLISH] [-l LANGUAGE] [-v VOLUNTEERS] [-f FINAL]
 
 Nina's Translation Tidyup Tool
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help            Show this help message and exit.
   -i INPUT, --input INPUT
                         The input directory which contains the content to tidy
                         up, defaults to the current folder.
   -o OUTPUT, --output OUTPUT
                         The output directory where the upgraded content should
                         be written, defaults to the same as input.
+  -e ENGLISH, --english ENGLISH
+                        The directory which contains the English files and
+                        folders, defaults to INPUT/../en.
+  -l LANGUAGE, --language LANGUAGE
+                        The language of the content to be tidied up, defaults
+                        to basename(INPUT).
+  -v VOLUNTEERS, --volunteers VOLUNTEERS
+                        The list of volunteers as a comma separated list,
+                        defaults to an empty list.
+  -f FINAL, --final FINAL
+                        The number of the final step file, defaults to the
+                        step file with the highest number.
 ```

--- a/README.md
+++ b/README.md
@@ -78,4 +78,69 @@ optional arguments:
   -f FINAL, --final FINAL
                         The number of the final step file, defaults to the
                         step file with the highest number.
+
+examples of usage:
+  nttt
+    Use the current directory (.) as input and output directory, ../en
+    (..\en on Windows) as English directory, and the last part of the
+    full path to the current directory as language. No volunteer names
+    will be added to the final step file and the step file with the
+    highest number is used as final step file.
+
+  nttt -i path/to/project/de-DE (macOS and Linux)
+  nttt -i path\to\project\de-DE (Windows)
+    Use path/to/project/de-DE (path\to\project\de-DE on Windows) as input
+    and output directory, path/to/project/en as English directory and de-DE
+    as language. No volunteer names will be added to the final step file
+    and the step file with the highest number is used as final step file.
+
+  nttt -o ../output (macOS and Linux)
+  nttt -o ..\output (Windows)
+    Use the current directory (.) as input directory, ../output
+    (..\output on Windows) as output directory, ../en
+    (..\en on Windows) as English directory, and the last part of the
+    full path to the current directory as language. No volunteer names
+    will be added to the final step file and the step file with the
+    highest number is used as final step file.
+
+  nttt -e some/other/path/en (macOS and Linux)
+  nttt -e some\other\path\en (Windows)
+    Use the current directory (.) as input and output directory,
+    some/other/path/en (some\other\path\en on Windows) as English
+    directory, and the last part of the full path to the current
+    directory as language. No volunteer names will be added to the
+    final step file and the step file with the highest number is
+    used as final step file.
+
+  nttt -l hi-IN
+    Use path/to/project/de-DE (path\to\project\de-DE on Windows) as input
+    and output directory, path/to/project/en as English directory and hi-IN
+    as language. No volunteer names will be added to the final step file
+    and the step file with the highest number is used as final step file.
+
+  nttt -v "Volunteer Translator, Volunteer Reviewer, Volunteer Tester"
+    Use the current directory (.) as input and output directory, ../en
+    (..\en on Windows) as English directory, and the last part of the
+    full path to the current directory as language. Three volunteer names
+    are added to the final step file: "Volunteer Translator",
+    "Volunteer Reviewer" and "Volunteer Tester". The step file with the
+    highest number is used as final step file.
+    Note that the list of volunteer names should be enclosed in quotes.
+    Also note that spaces at the beginning and end of the list as well
+    as spaces before and after commas will be discarded.
+
+  nttt -f 7
+    Use the current directory (.) as input and output directory, ../en
+    (..\en on Windows) as English directory, and the last part of the
+    full path to the current directory as language. No volunteer names
+    will be added to the final step file. File step_7.md will be used as
+    final step file.
+
+  nttt -i path/to/project/de-DE -o ../output -e some/other/path/en -l hi-IN \
+       -v "Volunteer Translator, Volunteer Reviewer, Volunteer Tester" -f 7
+	Use path/to/project/de-DE as input directory, ../output as output
+	directory, some/other/path/en as English directory, and hi-IN as
+    language. Three volunteer names are added to the final step file:
+    "Volunteer Translator", "Volunteer Reviewer" and "Volunteer Tester".
+    File step_7.md will be used as final step file.
 ```

--- a/nttt/__init__.py
+++ b/nttt/__init__.py
@@ -1,8 +1,9 @@
-from .arguments import get_arguments, check_arguments, show_arguments
+from .arguments import parse_command_line, get_arguments, check_arguments, show_arguments
 from .tidyup import tidyup_translations
 
 def main():
-    arguments = get_arguments()
+    command_line_args = parse_command_line()
+    arguments = get_arguments(command_line_args)
     show_arguments(arguments)
     if (check_arguments(arguments)):
         tidyup_translations(arguments)

--- a/nttt/__init__.py
+++ b/nttt/__init__.py
@@ -1,5 +1,8 @@
-from .arguments import get_arguments
+from .arguments import get_arguments, check_arguments, show_arguments
 from .tidyup import tidyup_translations
 
 def main():
-    tidyup_translations(get_arguments())
+    arguments = get_arguments()
+    show_arguments(arguments)
+    if (check_arguments(arguments)):
+        tidyup_translations(arguments)

--- a/nttt/__init__.py
+++ b/nttt/__init__.py
@@ -1,9 +1,10 @@
-from .arguments import parse_command_line, get_arguments, check_arguments, show_arguments
+from .arguments import parse_command_line, resolve_arguments, check_arguments, show_arguments
 from .tidyup import tidyup_translations
+
 
 def main():
     command_line_args = parse_command_line()
-    arguments = get_arguments(command_line_args)
-    show_arguments(arguments)
-    if (check_arguments(arguments)):
-        tidyup_translations(arguments)
+    resolved_arguments = resolve_arguments(command_line_args)
+    show_arguments(resolved_arguments)
+    if (check_arguments(resolved_arguments)):
+        tidyup_translations(resolved_arguments)

--- a/nttt/__init__.py
+++ b/nttt/__init__.py
@@ -1,20 +1,5 @@
+from .arguments import get_arguments
 from .tidyup import tidyup_translations
 
 def main():
-    from argparse import ArgumentParser
-
-    parser = ArgumentParser(description="Nina's Translation Tidyup Tool v 0.1.1-SNAPSHOT")
-    parser.add_argument("-i", "--input", help="The input directory which contains the content to tidy up, defaults to the current directory.")
-    parser.add_argument("-o", "--output", help="The output directory where the upgraded content should be written, defaults to the same as directory.")
-    args = parser.parse_args()
-
-    if args.input:
-        input_folder = args.input
-    else:
-        input_folder = "."
-
-    if args.output:
-        output_folder = args.output
-    else:
-        output_folder = input_folder
-    tidyup_translations(input_folder, output_folder)
+    tidyup_translations(get_arguments())

--- a/nttt/arguments.py
+++ b/nttt/arguments.py
@@ -12,7 +12,7 @@ def get_absolute_path(folder):
 def get_step_file(folder, step):
     '''Returns the step file for the given step number.'''
 
-    return Path("{}{}step_{}.md".format(folder, os.sep, str(step)))
+    return Path(folder, str(step))
 
 def get_final_step(folder):
     '''Returns the number of the final step file, or 0 in case there are no step files.'''
@@ -60,7 +60,7 @@ def get_arguments(command_line_args):
     if command_line_args.english:
         arguments[Constants.ENGLISH] = get_absolute_path(command_line_args.english)
     else:
-        arguments[Constants.ENGLISH] = Path(dirname(arguments[Constants.INPUT]) + os.sep + 'en')
+        arguments[Constants.ENGLISH] = Path(dirname(arguments[Constants.INPUT]), 'en')
 
     if command_line_args.language:
         arguments[Constants.LANGUAGE] = command_line_args.language

--- a/nttt/arguments.py
+++ b/nttt/arguments.py
@@ -1,21 +1,30 @@
-from .constants import Constants
+from .constants import ArgumentKeyConstants
 import os
 from pathlib import Path
 
+
 def get_absolute_path(folder):
-    '''Returns the absolute path for the given folder. Trailing path separators and double quotes are also removed.'''
+    '''
+    Returns the absolute path for the given folder. Trailing path separators
+    and double quotes are also removed.
+    '''
 
     folder = folder.strip().rstrip(os.pathsep).rstrip('"')
     folder = Path(folder).absolute()
     return folder
 
+
 def get_step_file(folder, step):
     '''Returns the step file for the given step number.'''
 
-    return Path(folder, str(step))
+    return Path(folder, "step_" + str(step) + ".md")
+
 
 def get_final_step(folder):
-    '''Returns the number of the final step file, or 0 in case there are no step files.'''
+    '''
+    Returns the number of the final step file, or 0 in case there are no step
+    files.
+    '''
 
     final_step = 0
     step = 1
@@ -26,71 +35,80 @@ def get_final_step(folder):
         step_file = get_step_file(folder, step)
     return final_step
 
+
 def parse_command_line():
-    '''Parses the command line and returns the arguments provided on command line.'''
+    '''
+    Parses the command line and returns the arguments provided on command line.
+    '''
 
     from argparse import ArgumentParser
 
     parser = ArgumentParser(description="Nina's Translation Tidyup Tool v 0.1.1-SNAPSHOT")
-    parser.add_argument("-i", "--input",      help = "The input directory which contains the content to tidy up, defaults to the current directory.")
-    parser.add_argument("-o", "--output",     help = "The output directory where the upgraded content should be written, defaults to the same as INPUT.")
-    parser.add_argument("-e", "--english",    help = "The directory which contains the English files and folders, defaults to INPUT/../en.")
-    parser.add_argument("-l", "--language",   help = "The language of the content to be tidied up, defaults to basename(INPUT).")
-    parser.add_argument("-v", "--volunteers", help = "The list of volunteers as a comma separated list, defaults to an empty list.")
-    parser.add_argument("-f", "--final",      help = "The number of the final step file, defaults to the step file with the highest number.")
+    parser.add_argument("-i", "--input",      help="The input directory which contains the content to tidy up, defaults to the current directory.")
+    parser.add_argument("-o", "--output",     help="The output directory where the upgraded content should be written, defaults to the same as INPUT.")
+    parser.add_argument("-e", "--english",    help="The directory which contains the English files and folders, defaults to INPUT/../en.")
+    parser.add_argument("-l", "--language",   help="The language of the content to be tidied up, defaults to basename(INPUT).")
+    parser.add_argument("-v", "--volunteers", help="The list of volunteers as a comma separated list, defaults to an empty list.")
+    parser.add_argument("-f", "--final",      help="The number of the final step file, defaults to the step file with the highest number.")
     return parser.parse_args()
 
-def get_arguments(command_line_args):
-    '''Returns the complete set of arguments. For arguments that are not provided on the command line, the default if used.'''
+
+def resolve_arguments(command_line_args):
+    '''
+    Returns the complete set of arguments. For arguments that are not provided
+    on the command line, the default is used.
+    '''
 
     from os.path import basename, dirname
 
     arguments = {}
 
     if command_line_args.input:
-        arguments[Constants.INPUT] = get_absolute_path(command_line_args.input)
+        arguments[ArgumentKeyConstants.INPUT] = get_absolute_path(command_line_args.input)
     else:
-        arguments[Constants.INPUT] = get_absolute_path('.')
+        arguments[ArgumentKeyConstants.INPUT] = get_absolute_path('.')
 
     if command_line_args.output:
-        arguments[Constants.OUTPUT] = get_absolute_path(command_line_args.output)
+        arguments[ArgumentKeyConstants.OUTPUT] = get_absolute_path(command_line_args.output)
     else:
-        arguments[Constants.OUTPUT] = arguments[Constants.INPUT]
+        arguments[ArgumentKeyConstants.OUTPUT] = arguments[ArgumentKeyConstants.INPUT]
 
     if command_line_args.english:
-        arguments[Constants.ENGLISH] = get_absolute_path(command_line_args.english)
+        arguments[ArgumentKeyConstants.ENGLISH] = get_absolute_path(command_line_args.english)
     else:
-        arguments[Constants.ENGLISH] = Path(dirname(arguments[Constants.INPUT]), 'en')
+        arguments[ArgumentKeyConstants.ENGLISH] = Path(dirname(arguments[ArgumentKeyConstants.INPUT]), 'en')
 
     if command_line_args.language:
-        arguments[Constants.LANGUAGE] = command_line_args.language
+        arguments[ArgumentKeyConstants.LANGUAGE] = command_line_args.language
     else:
-        arguments[Constants.LANGUAGE] = basename(arguments[Constants.INPUT])
+        arguments[ArgumentKeyConstants.LANGUAGE] = basename(arguments[ArgumentKeyConstants.INPUT])
 
     if command_line_args.volunteers:
-        arguments[Constants.VOLUNTEERS] = [name.strip() for name in command_line_args.volunteers.split(',')]
+        arguments[ArgumentKeyConstants.VOLUNTEERS] = [name.strip() for name in command_line_args.volunteers.split(',')]
     else:
-        arguments[Constants.VOLUNTEERS] = []
+        arguments[ArgumentKeyConstants.VOLUNTEERS] = []
 
     if command_line_args.final:
-        arguments[Constants.FINAL] = int(command_line_args.final)
+        arguments[ArgumentKeyConstants.FINAL] = int(command_line_args.final)
     else:
-        arguments[Constants.FINAL] = get_final_step(arguments[Constants.INPUT])
+        arguments[ArgumentKeyConstants.FINAL] = get_final_step(arguments[ArgumentKeyConstants.INPUT])
 
     return arguments
+
 
 def show_arguments(arguments):
     '''Shows the given arguments.'''
 
-    if arguments[Constants.INPUT] == arguments[Constants.OUTPUT]:
-        print("Using folder - {}".format(arguments[Constants.INPUT]))
+    if arguments[ArgumentKeyConstants.INPUT] == arguments[ArgumentKeyConstants.OUTPUT]:
+        print("Using folder - {}".format(arguments[ArgumentKeyConstants.INPUT]))
     else:
-        print("Input folder - '{}'".format(arguments[Constants.INPUT]))
-        print("Output folder - '{}'".format(arguments[Constants.OUTPUT]))
-    print("English folder - '{}'".format(arguments[Constants.ENGLISH]))
-    print("Language - '{}'".format(arguments[Constants.LANGUAGE]))
-    print("Volunteers - '{}'".format(arguments[Constants.VOLUNTEERS]))
-    print("Final step - '{}'".format(arguments[Constants.FINAL]))
+        print("Input folder - '{}'".format(arguments[ArgumentKeyConstants.INPUT]))
+        print("Output folder - '{}'".format(arguments[ArgumentKeyConstants.OUTPUT]))
+    print("English folder - '{}'".format(arguments[ArgumentKeyConstants.ENGLISH]))
+    print("Language - '{}'".format(arguments[ArgumentKeyConstants.LANGUAGE]))
+    print("Volunteers - '{}'".format(arguments[ArgumentKeyConstants.VOLUNTEERS]))
+    print("Final step - '{}'".format(arguments[ArgumentKeyConstants.FINAL]))
+
 
 def check_folder(folder):
     '''Checks whether the given folder exists and is a directory.'''
@@ -100,8 +118,9 @@ def check_folder(folder):
     valid = True
     if not os.path.isdir(folder):
         valid = False
-        print("Folder '{}' not found".format(folder), file = sys.stderr)
+        print("Folder '{}' not found".format(folder), file=sys.stderr)
     return valid
+
 
 def check_step_file(folder, step):
     '''Checks whether the step file for the given number exists.'''
@@ -112,19 +131,20 @@ def check_step_file(folder, step):
     step_file = get_step_file(folder, step)
     if not os.path.isfile(step_file):
         valid = False
-        print('Step file {} not found.'.format(step_file), file = sys.stderr)
+        print('Step file {} not found.'.format(step_file), file=sys.stderr)
     return valid
+
 
 def check_arguments(arguments):
     '''Checks whether the given arguments are valid.'''
 
     valid = True
-    if not check_folder(arguments[Constants.INPUT]):
+    if not check_folder(arguments[ArgumentKeyConstants.INPUT]):
         valid = False
-    if not check_folder(arguments[Constants.ENGLISH]):
+    if not check_folder(arguments[ArgumentKeyConstants.ENGLISH]):
         valid = False
-    if os.path.exists(arguments[Constants.OUTPUT]) and not check_folder(arguments[Constants.OUTPUT]):
+    if os.path.exists(arguments[ArgumentKeyConstants.OUTPUT]) and not check_folder(arguments[ArgumentKeyConstants.OUTPUT]):
         valid = False
-    if arguments[Constants.FINAL] > 0 and not check_step_file(arguments[Constants.INPUT], arguments[Constants.FINAL]):
+    if arguments[ArgumentKeyConstants.FINAL] > 0 and not check_step_file(arguments[ArgumentKeyConstants.INPUT], arguments[ArgumentKeyConstants.FINAL]):
         valid = False
     return valid

--- a/nttt/arguments.py
+++ b/nttt/arguments.py
@@ -1,0 +1,51 @@
+from .constants import INPUT, OUTPUT, ENGLISH, LANGUAGE, VOLUNTEERS, FINAL
+import os
+
+def get_arguments():
+    from argparse import ArgumentParser
+    from os.path import basename, dirname
+    from pathlib import Path
+
+    parser = ArgumentParser(description="Nina's Translation Tidyup Tool v 0.1.1-SNAPSHOT")
+    parser.add_argument("-i", "--input",      help="The input directory which contains the content to tidy up, defaults to the current directory.")
+    parser.add_argument("-o", "--output",     help="The output directory where the upgraded content should be written, defaults to the same as INPUT.")
+    parser.add_argument("-e", "--english",    help="The directory which contains the English files and folders, defaults to INPUT/../en.")
+    parser.add_argument("-l", "--language",   help="The language of the content to be tidied up, defaults to basename(INPUT).")
+    parser.add_argument("-v", "--volunteers", help="The list of volunteers as a comma separated list, defaults to an empty list.")
+    parser.add_argument("-f", "--final",      help="The number of the final step file, defaults to the step file with the highest number.")
+    args = parser.parse_args()
+
+    arguments = {}
+
+    if args.input:
+        arguments[INPUT] = args.input
+    else:
+        arguments[INPUT] = "."
+
+    if args.output:
+        arguments[OUTPUT] = args.output
+    else:
+        arguments[OUTPUT] = arguments[INPUT]
+
+    if args.english:
+        arguments[ENGLISH] = args.english
+    else:
+        arguments[ENGLISH] = dirname(Path(arguments[INPUT]).absolute()) + os.sep + 'en'
+
+    if args.language:
+        arguments[LANGUAGE] = args.language
+    else:
+        arguments[LANGUAGE] = basename(Path(arguments[INPUT]).absolute())
+
+    if args.volunteers:
+        arguments[VOLUNTEERS] = [name.strip() for name in args.volunteers.split(',')]
+    else:
+        arguments[VOLUNTEERS] = []
+
+    if args.final:
+        arguments[FINAL] = int(args.final)
+    else:
+        # TODO: find step file with highest number
+        arguments[FINAL] = -1
+
+    return arguments

--- a/nttt/arguments.py
+++ b/nttt/arguments.py
@@ -1,51 +1,105 @@
-from .constants import INPUT, OUTPUT, ENGLISH, LANGUAGE, VOLUNTEERS, FINAL
+from .constants import Constants
 import os
+from pathlib import Path
+
+def get_absolute_path(folder):
+    '''Returns the absolute path for the given folder. Trailing path separators and double quotes are also removed.'''
+
+    folder = folder.strip().rstrip(os.pathsep).rstrip('"')
+    folder = Path(folder).absolute()
+    return folder
+
+def get_final_step(folder):
+    '''Returns the number of the final step file.'''
+
+    final_step = 0
+    step = 1
+    step_file = Path("{}{}step_{}.md".format(folder, os.sep, str(step)))
+    while os.path.isfile(step_file):
+        final_step = step
+        step += 1
+        step_file = Path("{}{}step_{}.md".format(folder, os.sep, str(step)))
+    return final_step
 
 def get_arguments():
+    '''Returns the command line arguments. For arguments that are not provided ont he command line, the default if used.'''
+
     from argparse import ArgumentParser
     from os.path import basename, dirname
-    from pathlib import Path
 
     parser = ArgumentParser(description="Nina's Translation Tidyup Tool v 0.1.1-SNAPSHOT")
-    parser.add_argument("-i", "--input",      help="The input directory which contains the content to tidy up, defaults to the current directory.")
-    parser.add_argument("-o", "--output",     help="The output directory where the upgraded content should be written, defaults to the same as INPUT.")
-    parser.add_argument("-e", "--english",    help="The directory which contains the English files and folders, defaults to INPUT/../en.")
-    parser.add_argument("-l", "--language",   help="The language of the content to be tidied up, defaults to basename(INPUT).")
-    parser.add_argument("-v", "--volunteers", help="The list of volunteers as a comma separated list, defaults to an empty list.")
-    parser.add_argument("-f", "--final",      help="The number of the final step file, defaults to the step file with the highest number.")
+    parser.add_argument("-i", "--input",      help = "The input directory which contains the content to tidy up, defaults to the current directory.")
+    parser.add_argument("-o", "--output",     help = "The output directory where the upgraded content should be written, defaults to the same as INPUT.")
+    parser.add_argument("-e", "--english",    help = "The directory which contains the English files and folders, defaults to INPUT/../en.")
+    parser.add_argument("-l", "--language",   help = "The language of the content to be tidied up, defaults to basename(INPUT).")
+    parser.add_argument("-v", "--volunteers", help = "The list of volunteers as a comma separated list, defaults to an empty list.")
+    parser.add_argument("-f", "--final",      help = "The number of the final step file, defaults to the step file with the highest number.")
     args = parser.parse_args()
 
     arguments = {}
 
     if args.input:
-        arguments[INPUT] = args.input
+        arguments[Constants.INPUT] = get_absolute_path(args.input)
     else:
-        arguments[INPUT] = "."
+        arguments[Constants.INPUT] = get_absolute_path('.')
 
     if args.output:
-        arguments[OUTPUT] = args.output
+        arguments[Constants.OUTPUT] = get_absolute_path(args.output)
     else:
-        arguments[OUTPUT] = arguments[INPUT]
+        arguments[Constants.OUTPUT] = arguments[Constants.INPUT]
 
     if args.english:
-        arguments[ENGLISH] = args.english
+        arguments[Constants.ENGLISH] = get_absolute_path(args.english)
     else:
-        arguments[ENGLISH] = dirname(Path(arguments[INPUT]).absolute()) + os.sep + 'en'
+        arguments[Constants.ENGLISH] = dirname(arguments[Constants.INPUT]) + os.sep + 'en'
 
     if args.language:
-        arguments[LANGUAGE] = args.language
+        arguments[Constants.LANGUAGE] = args.language
     else:
-        arguments[LANGUAGE] = basename(Path(arguments[INPUT]).absolute())
+        arguments[Constants.LANGUAGE] = basename(arguments[Constants.INPUT])
 
     if args.volunteers:
-        arguments[VOLUNTEERS] = [name.strip() for name in args.volunteers.split(',')]
+        arguments[Constants.VOLUNTEERS] = [name.strip() for name in args.volunteers.split(',')]
     else:
-        arguments[VOLUNTEERS] = []
+        arguments[Constants.VOLUNTEERS] = []
 
     if args.final:
-        arguments[FINAL] = int(args.final)
+        arguments[Constants.FINAL] = int(args.final)
     else:
-        # TODO: find step file with highest number
-        arguments[FINAL] = -1
+        arguments[Constants.FINAL] = get_final_step(arguments[Constants.INPUT])
 
     return arguments
+
+def show_arguments(arguments):
+    '''Shows the given arguments.'''
+
+    if arguments[Constants.INPUT] == arguments[Constants.OUTPUT]:
+        print("Using folder - {}".format(arguments[Constants.INPUT]))
+    else:
+        print("Input folder - '{}'".format(arguments[Constants.INPUT]))
+        print("Output folder - '{}'".format(arguments[Constants.OUTPUT]))
+    print("English folder - '{}'".format(arguments[Constants.ENGLISH]))
+    print("Language - '{}'".format(arguments[Constants.LANGUAGE]))
+    print("Volunteers - '{}'".format(arguments[Constants.VOLUNTEERS]))
+    print("Final step - '{}'".format(arguments[Constants.FINAL]))
+
+def check_folder(folder):
+    '''Checks whether the given folder exists and is a directory.'''
+
+    import sys
+
+    valid = True
+    if not os.path.isdir(folder):
+        valid = False;
+        print("Folder '{}' not found".format(folder), file=sys.stderr)
+    return valid
+
+def check_arguments(arguments):
+    '''Checks whether the given arguments are valid.'''
+
+    valid = True
+    if not check_folder(arguments[Constants.INPUT]):
+        valid = False;
+    if not check_folder(arguments[Constants.ENGLISH]):
+        valid = False;
+    return valid

--- a/nttt/constants.py
+++ b/nttt/constants.py
@@ -1,8 +1,8 @@
-class Constants:
+class ArgumentKeyConstants:
     # Keys for the arguments dictionary
-    INPUT =      'INPUT'
-    OUTPUT =     'OUTPUT'
-    ENGLISH =    'ENGLISH'
-    LANGUAGE =   'LANGUAGE'
+    INPUT = 'INPUT'
+    OUTPUT = 'OUTPUT'
+    ENGLISH = 'ENGLISH'
+    LANGUAGE = 'LANGUAGE'
     VOLUNTEERS = 'VOLUNTEERS'
-    FINAL =      'FINAL'
+    FINAL = 'FINAL'

--- a/nttt/constants.py
+++ b/nttt/constants.py
@@ -1,7 +1,8 @@
-# Keys for the arguments dictionary
-INPUT = 'INPUT'
-OUTPUT = 'OUTPUT'
-ENGLISH = 'ENGLISH'
-LANGUAGE = 'LANGUAGE'
-VOLUNTEERS = 'VOLUNTEERS'
-FINAL = 'FINAL'
+class Constants:
+    # Keys for the arguments dictionary
+    INPUT =      'INPUT'
+    OUTPUT =     'OUTPUT'
+    ENGLISH =    'ENGLISH'
+    LANGUAGE =   'LANGUAGE'
+    VOLUNTEERS = 'VOLUNTEERS'
+    FINAL =      'FINAL'

--- a/nttt/constants.py
+++ b/nttt/constants.py
@@ -1,0 +1,7 @@
+# Keys for the arguments dictionary
+INPUT = 'INPUT'
+OUTPUT = 'OUTPUT'
+ENGLISH = 'ENGLISH'
+LANGUAGE = 'LANGUAGE'
+VOLUNTEERS = 'VOLUNTEERS'
+FINAL = 'FINAL'

--- a/nttt/tidyup.py
+++ b/nttt/tidyup.py
@@ -1,3 +1,4 @@
+from .constants import INPUT, OUTPUT, ENGLISH, LANGUAGE, VOLUNTEERS, FINAL
 from .utilities import find_files, find_replace, find_snippet, get_file, save_file
 
 import os
@@ -37,7 +38,14 @@ def fix_step(src, dst):
     #     bold_text = find_snippet(dst, "** ", " **")
 
 
-def tidyup_translations(folder, output_folder):
+def tidyup_translations(arguments):
+
+    folder = arguments[INPUT]
+    output_folder = arguments[OUTPUT]
+    english_folder = arguments[ENGLISH]
+    language = arguments[LANGUAGE]
+    volunteers = arguments[VOLUNTEERS]
+    final_step = arguments[FINAL]
 
     # tidy up and get absolute paths
     folder = folder.strip().rstrip(os.pathsep).rstrip('"')
@@ -46,7 +54,6 @@ def tidyup_translations(folder, output_folder):
     output_folder = Path(output_folder).absolute()
 
     if os.path.isdir(folder):
-
         
         # get files to update
         if folder == output_folder:
@@ -54,6 +61,10 @@ def tidyup_translations(folder, output_folder):
         else:
             print("Input folder - '{}'".format(folder))
             print("Output folder - '{}'".format(output_folder))
+        print("English folder - '{}'".format(english_folder))
+        print("Language - '{}'".format(language))
+        print("Volunteers - '{}'".format(volunteers))
+        print("Final step - '{}'".format(final_step))
     
         print("Find files ...")
         files_to_update = find_files(folder, file_names=["meta.yml"], extensions=[".md"])

--- a/nttt/tidyup.py
+++ b/nttt/tidyup.py
@@ -1,12 +1,14 @@
-from .constants import Constants
+from .constants import ArgumentKeyConstants
 from .utilities import find_files, find_replace, find_snippet, get_file, save_file
 
 import os.path
 
+
 def fix_meta(src, dst):
     find_replace(src, dst, "  - \n    title:", "  - title:")
 
-def fix_step(src, dst, lang):
+
+def fix_step(src, lang, dst):
     content, suggested_eol = get_file(src)
     content = content.replace("\---", "---")
     content = content.replace("## ---", "---")
@@ -16,7 +18,7 @@ def fix_step(src, dst, lang):
     content = content.replace(" --- /hints ---", "--- /hints ---")
     content = content.replace('{: target = " blank"}', '{:target="blank"}')
     content = content.replace("\n` ", "\n`")
-    
+
     collapse_error = "--- collapse ---\n\n## title: "
     collapse_title = find_snippet(content, collapse_error, "\n")
     while collapse_title is not None:
@@ -37,12 +39,12 @@ def fix_step(src, dst, lang):
 
 def tidyup_translations(arguments):
 
-    folder = arguments[Constants.INPUT]
-    output_folder = arguments[Constants.OUTPUT]
-    # english_folder = arguments[Constants.ENGLISH]
-    language = arguments[Constants.LANGUAGE]
-    # volunteers = arguments[Constants.VOLUNTEERS]
-    # final_step = arguments[Constants.FINAL]
+    folder = arguments[ArgumentKeyConstants.INPUT]
+    output_folder = arguments[ArgumentKeyConstants.OUTPUT]
+    # english_folder = arguments[ArgumentKeyConstants.ENGLISH]
+    language = arguments[ArgumentKeyConstants.LANGUAGE]
+    # volunteers = arguments[ArgumentKeyConstants.VOLUNTEERS]
+    # final_step = arguments[ArgumentKeyConstants.FINAL]
 
     # get files to update
     print("Find files ...")
@@ -52,7 +54,7 @@ def tidyup_translations(arguments):
         print("About to tidy up files:")
         for file in files_to_update:
             print(" - {}".format(file.replace(str(folder), "")))
-        
+
         process_yn = input("Continue (y/n):")
         if process_yn.casefold() == "y":
 
@@ -60,10 +62,9 @@ def tidyup_translations(arguments):
                 file_name = source_file_path.replace(str(folder), "")
 
                 output_file_path = str(output_folder) + file_name
-                
+
                 # create output folder
                 output_file_folder = os.path.dirname(output_file_path)
-
 
                 if not os.path.exists(output_file_folder):
                     os.makedirs(output_file_folder)
@@ -73,8 +74,8 @@ def tidyup_translations(arguments):
                     fix_meta(source_file_path, output_file_path)
                 else:
                     fix_step(source_file_path, output_file_path, language)
-            
+
             print("Complete")
-                
+
     else:
         print("No files found in '{}'".format(folder))

--- a/nttt/tidyup.py
+++ b/nttt/tidyup.py
@@ -6,7 +6,7 @@ import os.path
 def fix_meta(src, dst):
     find_replace(src, dst, "  - \n    title:", "  - title:")
 
-def fix_step(src, dst, lang):
+def fix_step(src, dst, lang = "nl-NL"):
     content, suggested_eol = get_file(src)
     content = content.replace("\---", "---")
     content = content.replace("## ---", "---")

--- a/nttt/tidyup.py
+++ b/nttt/tidyup.py
@@ -6,7 +6,7 @@ import os.path
 def fix_meta(src, dst):
     find_replace(src, dst, "  - \n    title:", "  - title:")
 
-def fix_step(src, dst, lang = "nl-NL"):
+def fix_step(src, dst, lang):
     content, suggested_eol = get_file(src)
     content = content.replace("\---", "---")
     content = content.replace("## ---", "---")

--- a/unit_test/test_arguments.py
+++ b/unit_test/test_arguments.py
@@ -4,37 +4,45 @@ import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+
 class TestArguments(unittest.TestCase):
+
+    def test_get_step_file(self):
+        '''Test case for the get_step_file function.'''
+
+        with TemporaryDirectory() as temp_folder:
+            result = nttt.arguments.get_step_file(temp_folder, 17)
+            self.assertEqual(result, Path(str(temp_folder), "step_17.md"))
 
     def test_get_final_step(self):
         ''' Test case for the get_final_step function:
         - If there are no step files, the function should return 0.
-        - If there is one step file, called step_1.md, the function should return 1.
-        - If there are two step files, called step_1.md and step_2.md, the function should return 2.
-        - If there are three step files, called step_1.md, step__2.md and step_4.md, the function should return 2.
+        - If there is one step file, called step_1.md, the function should
+          return 1.
+        - If there are two step files, called step_1.md and step_2.md, the
+          function should return 2.
+        - If there are three step files, called step_1.md, step__2.md and
+          step_4.md, the function should return 2.
         '''
 
         with TemporaryDirectory() as temp_folder:
             result = nttt.arguments.get_final_step(temp_folder)
             self.assertEqual(result, 0)
 
-            step_file = nttt.arguments.get_step_file(temp_folder, 1)
-            step_file.touch()
+            Path(temp_folder, "step_1.md").touch()
             result = nttt.arguments.get_final_step(temp_folder)
             self.assertEqual(result, 1)
 
-            step_file = nttt.arguments.get_step_file(temp_folder, 2)
-            step_file.touch()
+            Path(temp_folder, "step_2.md").touch()
             result = nttt.arguments.get_final_step(temp_folder)
             self.assertEqual(result, 2)
 
-            step_file = nttt.arguments.get_step_file(temp_folder, 4)
-            step_file.touch()
+            Path(temp_folder, "step_4.md").touch()
             result = nttt.arguments.get_final_step(temp_folder)
             self.assertEqual(result, 2)
 
     def test_get_arguments(self):
-        ''' Test case for the get_arguments function:
+        ''' Test case for the resolve_arguments function:
         - Without any command line arguments specified, the defaults are used.
         - With the command line arguments specified, those values are used.
         '''
@@ -42,17 +50,18 @@ class TestArguments(unittest.TestCase):
         class CommandLineArgs():
             '''Simple placeholder for command line arguments.'''
             def __init__(self):
-                self.input =      False
-                self.output =     False
-                self.english =    False
-                self.language =   False
+                self.input = False
+                self.output = False
+                self.english = False
+                self.language = False
                 self.volunteers = False
-                self.final =      False
+                self.final = False
 
-        # Using the os.chdir function for a subdirectory of a directory created with
-        # TemporaryDirectory doesn't work on Windows and macOS. Therefore, this test
-        # case uses directories below the directory that contains this test case (i.e.
-        # "unit_test"). These directories have to be present in the repository.
+        # Using the os.chdir function for a subdirectory of a directory created
+        # with TemporaryDirectory doesn't work on Windows and macOS. Therefore,
+        # this test case uses directories below the directory that contains
+        # this test case (i.e. "unit_test"). These directories have to be
+        # present in the repository.
         data_folder = Path(os.getcwd(), "unit_test", "data")
         self.assertTrue(data_folder.is_dir(), "Subdirectory data of directory unit_test is missing.")
         input_folder = Path(data_folder, "hi-IN")
@@ -63,13 +72,13 @@ class TestArguments(unittest.TestCase):
 
         # Defaults for all arguments.
         command_line_args = CommandLineArgs()
-        arguments = nttt.arguments.get_arguments(command_line_args)
-        self.assertEqual(arguments[nttt.arguments.Constants.INPUT],      input_folder)
-        self.assertEqual(arguments[nttt.arguments.Constants.OUTPUT],     output_folder)
-        self.assertEqual(arguments[nttt.arguments.Constants.ENGLISH],    english_folder)
-        self.assertEqual(arguments[nttt.arguments.Constants.LANGUAGE],   "hi-IN")
-        self.assertEqual(arguments[nttt.arguments.Constants.VOLUNTEERS], [])
-        self.assertEqual(arguments[nttt.arguments.Constants.FINAL],      0)
+        arguments = nttt.arguments.resolve_arguments(command_line_args)
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.INPUT], input_folder)
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.OUTPUT], output_folder)
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.ENGLISH], english_folder)
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.LANGUAGE], "hi-IN")
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.VOLUNTEERS], [])
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.FINAL], 0)
 
         input_folder = Path(data_folder, "da-DK")
         output_folder = Path(data_folder, "output")
@@ -77,19 +86,19 @@ class TestArguments(unittest.TestCase):
         os.chdir(data_folder)
 
         # Specify all arguments.
-        command_line_args.input =      "da-DK"
-        command_line_args.output =     "output"
-        command_line_args.english =    "en-GB"
-        command_line_args.language =   "de-DE"
+        command_line_args.input = "da-DK"
+        command_line_args.output = "output"
+        command_line_args.english = "en-GB"
+        command_line_args.language = "de-DE"
         command_line_args.volunteers = " Volunteer One , Volunteer Two "
-        command_line_args.final =      5
-        arguments = nttt.arguments.get_arguments(command_line_args)
-        self.assertEqual(arguments[nttt.arguments.Constants.INPUT],      input_folder)
-        self.assertEqual(arguments[nttt.arguments.Constants.OUTPUT],     output_folder)
-        self.assertEqual(arguments[nttt.arguments.Constants.ENGLISH],    english_folder)
-        self.assertEqual(arguments[nttt.arguments.Constants.LANGUAGE],   "de-DE")
-        self.assertEqual(arguments[nttt.arguments.Constants.VOLUNTEERS], ["Volunteer One", "Volunteer Two"])
-        self.assertEqual(arguments[nttt.arguments.Constants.FINAL],      5)
+        command_line_args.final = 5
+        arguments = nttt.arguments.resolve_arguments(command_line_args)
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.INPUT], input_folder)
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.OUTPUT], output_folder)
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.ENGLISH], english_folder)
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.LANGUAGE], "de-DE")
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.VOLUNTEERS], ["Volunteer One", "Volunteer Two"])
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.FINAL], 5)
 
     def test_check_folder(self):
         ''' Test case for the check_folder function:
@@ -125,8 +134,7 @@ class TestArguments(unittest.TestCase):
             result = nttt.arguments.check_step_file(temp_folder, 3)
             self.assertFalse(result)
 
-            step_file = nttt.arguments.get_step_file(temp_folder, 3)
-            step_file.touch()
+            Path(temp_folder, "step_3.md").touch()
             result = nttt.arguments.check_step_file(temp_folder, 3)
             self.assertTrue(result)
 
@@ -134,55 +142,57 @@ class TestArguments(unittest.TestCase):
         ''' Test case for the check_arguments function:
         - The function should return False if the input folder doesn't exist.
         - The function should return False if the English folder doesn't exist.
-        - The function should return False if the output folder exists, but is not a folder.
-        - The function should return False if the final step is specified, but the step file doesn't exist.
+        - The function should return False if the output folder exists, but is
+          not a folder.
+        - The function should return False if the final step is specified, but
+          the step file doesn't exist.
         - The function should return True in any other case.
         '''
 
         with TemporaryDirectory() as temp_folder:
             arguments = {}
-            arguments[nttt.arguments.Constants.INPUT] =      Path(temp_folder, "uk-UA")
-            arguments[nttt.arguments.Constants.OUTPUT] =     Path(temp_folder, "output")
-            arguments[nttt.arguments.Constants.ENGLISH] =    Path(temp_folder, "en")
-            arguments[nttt.arguments.Constants.LANGUAGE] =   "uk-UA"
-            arguments[nttt.arguments.Constants.VOLUNTEERS] = []
-            arguments[nttt.arguments.Constants.FINAL] =      0
+            arguments[nttt.arguments.ArgumentKeyConstants.INPUT] = Path(temp_folder, "uk-UA")
+            arguments[nttt.arguments.ArgumentKeyConstants.OUTPUT] = Path(temp_folder, "output")
+            arguments[nttt.arguments.ArgumentKeyConstants.ENGLISH] = Path(temp_folder, "en")
+            arguments[nttt.arguments.ArgumentKeyConstants.LANGUAGE] = "uk-UA"
+            arguments[nttt.arguments.ArgumentKeyConstants.VOLUNTEERS] = []
+            arguments[nttt.arguments.ArgumentKeyConstants.FINAL] = 0
 
             # Input and English folder don't exist. Output folder and final step are OK.
             result = nttt.arguments.check_arguments(arguments)
             self.assertFalse(result)
 
             # Create input folder. English folder still doesn't exist.
-            os.mkdir(arguments[nttt.arguments.Constants.INPUT])
+            os.mkdir(arguments[nttt.arguments.ArgumentKeyConstants.INPUT])
             result = nttt.arguments.check_arguments(arguments)
             self.assertFalse(result)
 
             # Create English folder as well.
-            os.mkdir(arguments[nttt.arguments.Constants.ENGLISH])
+            os.mkdir(arguments[nttt.arguments.ArgumentKeyConstants.ENGLISH])
             result = nttt.arguments.check_arguments(arguments)
             self.assertTrue(result)
 
             # Final step file doesn't exist.
-            arguments[nttt.arguments.Constants.FINAL] = 3
+            arguments[nttt.arguments.ArgumentKeyConstants.FINAL] = 3
             result = nttt.arguments.check_arguments(arguments)
             self.assertFalse(result)
 
             # Create final step file.
-            step_file = nttt.arguments.get_step_file(arguments[nttt.arguments.Constants.INPUT], 3)
-            step_file.touch()
+            Path(arguments[nttt.arguments.ArgumentKeyConstants.INPUT], "step_3.md").touch()
             result = nttt.arguments.check_arguments(arguments)
             self.assertTrue(result)
 
             # Create output folder as file.
-            arguments[nttt.arguments.Constants.OUTPUT].touch()
+            arguments[nttt.arguments.ArgumentKeyConstants.OUTPUT].touch()
             result = nttt.arguments.check_arguments(arguments)
             self.assertFalse(result)
 
             # Create proper output folder.
-            os.remove(arguments[nttt.arguments.Constants.OUTPUT])
-            os.mkdir(arguments[nttt.arguments.Constants.OUTPUT])
+            os.remove(arguments[nttt.arguments.ArgumentKeyConstants.OUTPUT])
+            os.mkdir(arguments[nttt.arguments.ArgumentKeyConstants.OUTPUT])
             result = nttt.arguments.check_arguments(arguments)
             self.assertTrue(result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_test/test_arguments.py
+++ b/unit_test/test_arguments.py
@@ -1,0 +1,186 @@
+import unittest
+import nttt
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+class TestArguments(unittest.TestCase):
+
+    def test_get_final_step(self):
+        ''' Test case for the get_final_step function:
+        - If there are no step files, the function should return 0.
+        - If there is one step file, called step_1.md, the function should return 1.
+        - If there are two step files, called step_1.md and step_2.md, the function should return 2.
+        - If there are three step files, called step_1.md, step__2.md and step_4.md, the function should return 2.
+        '''
+
+        with TemporaryDirectory() as temp_folder:
+            result = nttt.arguments.get_final_step(temp_folder)
+            self.assertEqual(result, 0)
+
+            step_file = nttt.arguments.get_step_file(temp_folder, 1)
+            step_file.touch()
+            result = nttt.arguments.get_final_step(temp_folder)
+            self.assertEqual(result, 1)
+
+            step_file = nttt.arguments.get_step_file(temp_folder, 2)
+            step_file.touch()
+            result = nttt.arguments.get_final_step(temp_folder)
+            self.assertEqual(result, 2)
+
+            step_file = nttt.arguments.get_step_file(temp_folder, 4)
+            step_file.touch()
+            result = nttt.arguments.get_final_step(temp_folder)
+            self.assertEqual(result, 2)
+
+    def test_get_arguments(self):
+        ''' Test case for the get_arguments function:
+        - Without any command line arguments specified, the defaults are used.
+        - With the command line arguments specified, those values are used.
+        '''
+
+        if os.name == 'nt':
+            # FIXME: This test case doesn't run on Windows, because the os.chdir function doesn't seem to
+            # work on Path objects.
+            return
+
+        class CommandLineArgs():
+            def __init__(self):
+                self.input =      False
+                self.output =     False
+                self.english =    False
+                self.language =   False
+                self.volunteers = False
+                self.final =      False
+
+        with TemporaryDirectory() as temp_folder:
+            input_folder = Path("{}{}hi-IN".format(temp_folder, os.sep))
+            english_folder = Path("{}{}en".format(temp_folder, os.sep))
+            os.mkdir(input_folder)
+            os.chdir(input_folder)
+
+            # Defaults for all arguments.
+            command_line_args = CommandLineArgs()
+            arguments = nttt.arguments.get_arguments(command_line_args)
+            self.assertEqual(arguments[nttt.arguments.Constants.INPUT],      input_folder)
+            self.assertEqual(arguments[nttt.arguments.Constants.OUTPUT],     input_folder)
+            self.assertEqual(arguments[nttt.arguments.Constants.ENGLISH],    english_folder)
+            self.assertEqual(arguments[nttt.arguments.Constants.LANGUAGE],   "hi-IN")
+            self.assertEqual(arguments[nttt.arguments.Constants.VOLUNTEERS], [])
+            self.assertEqual(arguments[nttt.arguments.Constants.FINAL],      0)
+
+            input_folder = Path("{}{}da-DK".format(temp_folder, os.sep))
+            output_folder = Path("{}{}output".format(temp_folder, os.sep))
+            english_folder = Path("{}{}en-GB".format(temp_folder, os.sep))
+            os.chdir(temp_folder)
+
+            # Specify all arguments.
+            command_line_args.input =      "da-DK"
+            command_line_args.output =     "output"
+            command_line_args.english =    "en-GB"
+            command_line_args.language =   "de-DE"
+            command_line_args.volunteers = " Volunteer One , Volunteer Two "
+            command_line_args.final =      5
+            arguments = nttt.arguments.get_arguments(command_line_args)
+            self.assertEqual(arguments[nttt.arguments.Constants.INPUT],      input_folder)
+            self.assertEqual(arguments[nttt.arguments.Constants.OUTPUT],     output_folder)
+            self.assertEqual(arguments[nttt.arguments.Constants.ENGLISH],    english_folder)
+            self.assertEqual(arguments[nttt.arguments.Constants.LANGUAGE],   "de-DE")
+            self.assertEqual(arguments[nttt.arguments.Constants.VOLUNTEERS], ["Volunteer One", "Volunteer Two"])
+            self.assertEqual(arguments[nttt.arguments.Constants.FINAL],      5)
+
+    def test_check_folder(self):
+        ''' Test case for the check_folder function:
+        - The function should return True for an existing folder.
+        - The function should return False for an existing file.
+        - The function should return False for non-existing folder.
+        '''
+
+        with TemporaryDirectory() as temp_folder:
+            result = nttt.arguments.check_folder(temp_folder)
+            self.assertEqual(result, True)
+
+            test_file = Path("{}{}test_file".format(temp_folder, os.sep))
+            test_file.touch()
+            result = nttt.arguments.check_folder(test_file)
+            self.assertEqual(result, False)
+
+            test_dir = Path("{}{}test_dir".format(temp_folder, os.sep))
+            result = nttt.arguments.check_folder(test_dir)
+            self.assertEqual(result, False)
+
+            os.mkdir(test_dir)
+            result = nttt.arguments.check_folder(test_dir)
+            self.assertEqual(result, True)
+
+    def test_check_step_file(self):
+        ''' Test case for the check_step_file function:
+        - The function should return False for a non-existing file.
+        - The function should return True for an existing file.
+        '''
+
+        with TemporaryDirectory() as temp_folder:
+            result = nttt.arguments.check_step_file(temp_folder, 3)
+            self.assertEqual(result, False)
+
+            step_file = nttt.arguments.get_step_file(temp_folder, 3)
+            step_file.touch()
+            result = nttt.arguments.check_step_file(temp_folder, 3)
+            self.assertEqual(result, True)
+
+    def test_check_arguments(self):
+        ''' Test case for the check_arguments function:
+        - The function should return False if the input folder doesn't exist.
+        - The function should return False if the English folder doesn't exist.
+        - The function should return False if the output folder exists, but is not a folder.
+        - The function should return False if the final step is specified, but the step file doesn't exist.
+        - The function should return True in any other case.
+        '''
+
+        with TemporaryDirectory() as temp_folder:
+            arguments = {}
+            arguments[nttt.arguments.Constants.INPUT] =      Path("{}{}uk-UA".format(temp_folder, os.sep))
+            arguments[nttt.arguments.Constants.OUTPUT] =     Path("{}{}output".format(temp_folder, os.sep))
+            arguments[nttt.arguments.Constants.ENGLISH] =    Path("{}{}en".format(temp_folder, os.sep))
+            arguments[nttt.arguments.Constants.LANGUAGE] =   "uk-UA"
+            arguments[nttt.arguments.Constants.VOLUNTEERS] = []
+            arguments[nttt.arguments.Constants.FINAL] =      0
+
+            # Input and English folder don't exist. Output folder and final step are OK.
+            result = nttt.arguments.check_arguments(arguments)
+            self.assertEqual(result, False)
+
+            # Create input folder. English folder still doesn't exist.
+            os.mkdir(arguments[nttt.arguments.Constants.INPUT])
+            result = nttt.arguments.check_arguments(arguments)
+            self.assertEqual(result, False)
+
+            # Create English folder as well.
+            os.mkdir(arguments[nttt.arguments.Constants.ENGLISH])
+            result = nttt.arguments.check_arguments(arguments)
+            self.assertEqual(result, True)
+
+            # Final step file doesn't exist.
+            arguments[nttt.arguments.Constants.FINAL] = 3
+            result = nttt.arguments.check_arguments(arguments)
+            self.assertEqual(result, False)
+
+            # Create final step file.
+            step_file = nttt.arguments.get_step_file(arguments[nttt.arguments.Constants.INPUT], 3)
+            step_file.touch()
+            result = nttt.arguments.check_arguments(arguments)
+            self.assertEqual(result, True)
+
+            # Create output folder as file.
+            arguments[nttt.arguments.Constants.OUTPUT].touch()
+            result = nttt.arguments.check_arguments(arguments)
+            self.assertEqual(result, False)
+
+            # Create proper output folder.
+            os.remove(arguments[nttt.arguments.Constants.OUTPUT])
+            os.mkdir(arguments[nttt.arguments.Constants.OUTPUT])
+            result = nttt.arguments.check_arguments(arguments)
+            self.assertEqual(result, True)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_test/test_eol.py
+++ b/unit_test/test_eol.py
@@ -5,7 +5,7 @@ from unit_test.test_utilities import CustomNamedTemporaryFile
 
 class TestEol(unittest.TestCase):
     def test_fix_metadata_crlf(self):
-        self.assert_function_call(nttt.tidyup.fix_meta,
+        self.assert_function_call_2args(nttt.tidyup.fix_meta,
                                   "---\r\n"
                                   "steps:\r\n"
                                   "  - \r\n"
@@ -16,7 +16,7 @@ class TestEol(unittest.TestCase):
                                   "  - title: Inleiding\r\n")
 
     def test_fix_metadata_lf(self):
-        self.assert_function_call(nttt.tidyup.fix_meta,
+        self.assert_function_call_2args(nttt.tidyup.fix_meta,
                                   "---\n"
                                   "steps:\n"
                                   "  - \n"
@@ -27,7 +27,7 @@ class TestEol(unittest.TestCase):
                                   "  - title: Inleiding\n")
 
     def test_fix_collapse_block_crlf(self):
-        self.assert_function_call(nttt.tidyup.fix_step,
+        self.assert_function_call_3args(nttt.tidyup.fix_step,
                                   "--- collapse ---\r\n"
                                   "\r\n"
                                   "## title: My title\r\n",
@@ -35,10 +35,12 @@ class TestEol(unittest.TestCase):
                                   "--- collapse ---\r\n"
                                   "---\r\n"
                                   "title: My title\r\n"
-                                  "---\r\n")
+                                  "---\r\n",
+                                  
+                                  "el-GR")
 
     def test_fix_collapse_block_lf(self):
-        self.assert_function_call(nttt.tidyup.fix_step,
+        self.assert_function_call_3args(nttt.tidyup.fix_step,
                                   "--- collapse ---\n"
                                   "\n"
                                   "## title: My title\n",
@@ -46,9 +48,11 @@ class TestEol(unittest.TestCase):
                                   "--- collapse ---\n"
                                   "---\n"
                                   "title: My title\n"
-                                  "---\n")
+                                  "---\n",
+                                  
+                                  "es-ES")
 
-    def assert_function_call(self, func, input_file_content, expected_output_file_content):
+    def assert_function_call_2args(self, func, input_file_content, expected_output_file_content):
         """
         - Prepare input file
         - Run the given function (that takes as arguments names of input and output files)
@@ -60,6 +64,22 @@ class TestEol(unittest.TestCase):
             temp_src.flush()
 
             func(temp_src.name, temp_dest.name)
+
+            result = temp_dest.read().decode('utf-8')
+            self.assertEqual(result, expected_output_file_content)
+
+    def assert_function_call_3args(self, func, input_file_content, expected_output_file_content, language):
+        """
+        - Prepare input file
+        - Run the given function (that takes as arguments names of input and output files)
+        - Assert that the output file has the expected content
+        """
+        with CustomNamedTemporaryFile(mode="wb", delete=True) as temp_src, \
+                CustomNamedTemporaryFile(mode="rb", delete=True) as temp_dest:
+            temp_src.write(input_file_content.encode('utf-8'))
+            temp_src.flush()
+
+            func(temp_src.name, temp_dest.name, language)
 
             result = temp_dest.read().decode('utf-8')
             self.assertEqual(result, expected_output_file_content)

--- a/unit_test/test_eol.py
+++ b/unit_test/test_eol.py
@@ -6,51 +6,51 @@ from unit_test.test_utilities import CustomNamedTemporaryFile
 class TestEol(unittest.TestCase):
     def test_fix_metadata_crlf(self):
         self.assert_function_call_2args(nttt.tidyup.fix_meta,
-                                  "---\r\n"
-                                  "steps:\r\n"
-                                  "  - \r\n"
-                                  "    title: Inleiding\r\n",
+                                        "---\r\n"
+                                        "steps:\r\n"
+                                        "  - \r\n"
+                                        "    title: Inleiding\r\n",
 
-                                  "---\r\n"
-                                  "steps:\r\n"
-                                  "  - title: Inleiding\r\n")
+                                        "---\r\n"
+                                        "steps:\r\n"
+                                        "  - title: Inleiding\r\n")
 
     def test_fix_metadata_lf(self):
         self.assert_function_call_2args(nttt.tidyup.fix_meta,
-                                  "---\n"
-                                  "steps:\n"
-                                  "  - \n"
-                                  "    title: Inleiding\n",
+                                        "---\n"
+                                        "steps:\n"
+                                        "  - \n"
+                                        "    title: Inleiding\n",
 
-                                  "---\n"
-                                  "steps:\n"
-                                  "  - title: Inleiding\n")
+                                        "---\n"
+                                        "steps:\n"
+                                        "  - title: Inleiding\n")
 
     def test_fix_collapse_block_crlf(self):
         self.assert_function_call_3args(nttt.tidyup.fix_step,
-                                  "--- collapse ---\r\n"
-                                  "\r\n"
-                                  "## title: My title\r\n",
+                                        "--- collapse ---\r\n"
+                                        "\r\n"
+                                        "## title: My title\r\n",
 
-                                  "--- collapse ---\r\n"
-                                  "---\r\n"
-                                  "title: My title\r\n"
-                                  "---\r\n",
-                                  
-                                  "el-GR")
+                                        "el-GR",
+
+                                        "--- collapse ---\r\n"
+                                        "---\r\n"
+                                        "title: My title\r\n"
+                                        "---\r\n")
 
     def test_fix_collapse_block_lf(self):
         self.assert_function_call_3args(nttt.tidyup.fix_step,
-                                  "--- collapse ---\n"
-                                  "\n"
-                                  "## title: My title\n",
+                                        "--- collapse ---\n"
+                                        "\n"
+                                        "## title: My title\n",
 
-                                  "--- collapse ---\n"
-                                  "---\n"
-                                  "title: My title\n"
-                                  "---\n",
-                                  
-                                  "es-ES")
+                                        "es-ES",
+
+                                        "--- collapse ---\n"
+                                        "---\n"
+                                        "title: My title\n"
+                                        "---\n")
 
     def assert_function_call_2args(self, func, input_file_content, expected_output_file_content):
         """
@@ -68,7 +68,7 @@ class TestEol(unittest.TestCase):
             result = temp_dest.read().decode('utf-8')
             self.assertEqual(result, expected_output_file_content)
 
-    def assert_function_call_3args(self, func, input_file_content, expected_output_file_content, language):
+    def assert_function_call_3args(self, func, input_file_content, second_argument, expected_output_file_content):
         """
         - Prepare input file
         - Run the given function (that takes as arguments names of input and output files)
@@ -79,7 +79,7 @@ class TestEol(unittest.TestCase):
             temp_src.write(input_file_content.encode('utf-8'))
             temp_src.flush()
 
-            func(temp_src.name, temp_dest.name, language)
+            func(temp_src.name, second_argument, temp_dest.name)
 
             result = temp_dest.read().decode('utf-8')
             self.assertEqual(result, expected_output_file_content)


### PR DESCRIPTION
This is the implementation of issue [#16](https://github.com/wheleph/nttt/issues/16), including a unit test. All arguments can now be specified on the command line (and are also validated), but only the input folder, the output folder and the language arguments are actually used by nttt at this moment. The other arguments will be used when other issues are implemented.