### PR TITLE
Introduce --Yes instead of --Silent

### DIFF
--- a/nttt/arguments.py
+++ b/nttt/arguments.py
@@ -58,8 +58,8 @@ def parse_command_line(version):
                                                    "fix_formatting (fix common issues in formatting tags ({:class=\"block3motion\"})). "
                                                    "Defaults to all risky features to be enabled.")
     parser.add_argument("-L", "--Logging",    help="Logging of modifications. Options are on and off. Default is off.")
-    parser.add_argument("-S", "--Silent",     help="Enables or disables the silent mode. "
-                                                   "In silent mode the tool runs without prompting users for confirmations. "
+    parser.add_argument("-Y", "--Yes",        help="Automatic yes to prompts. "
+                                                   "If enabled assume 'yes' as answer to all prompts and run non-interactively. "
                                                    "Options are on and off. Default is off.")
     return parser.parse_args()
 
@@ -114,10 +114,10 @@ def resolve_arguments(command_line_args):
     else:
         arguments[ArgumentKeyConstants.LOGGING] = "off"
 
-    if command_line_args.Silent:
-        arguments[ArgumentKeyConstants.SILENT] = command_line_args.Silent
+    if command_line_args.Yes:
+        arguments[ArgumentKeyConstants.YES] = command_line_args.Yes
     else:
-        arguments[ArgumentKeyConstants.SILENT] = "off"
+        arguments[ArgumentKeyConstants.YES] = "off"
 
     return arguments
 
@@ -136,7 +136,7 @@ def show_arguments(arguments):
     print("Final step - '{}'".format(arguments[ArgumentKeyConstants.FINAL]))
     print("Disabled functions - '{}'".format(arguments[ArgumentKeyConstants.DISABLE]))
     print("Logging - '{}'".format(arguments[ArgumentKeyConstants.LOGGING]))
-    print("Silent - '{}'".format(arguments[ArgumentKeyConstants.SILENT]))
+    print("Yes - '{}'".format(arguments[ArgumentKeyConstants.YES]))
 
 
 def check_folder(folder):

--- a/nttt/arguments.py
+++ b/nttt/arguments.py
@@ -1,6 +1,7 @@
 from .constants import ArgumentKeyConstants
 import os
 from pathlib import Path
+from argparse import ArgumentParser
 
 
 def get_absolute_path(folder):
@@ -37,11 +38,11 @@ def get_final_step(folder):
 
 
 def parse_command_line(version):
-    '''
+    """
     Parses the command line and returns the arguments provided on command line.
-    '''
-
-    from argparse import ArgumentParser
+    The convention is to begin functional flag names with a small letter
+    and non-functional flag names with a capital letter
+    """
 
     parser = ArgumentParser(description="Nina's Translation Tidyup Tool v{}".format(version))
     parser.add_argument("-i", "--input",      help="The input directory which contains the content to tidy up, defaults to the current directory.")

--- a/nttt/constants.py
+++ b/nttt/constants.py
@@ -16,7 +16,7 @@ class ArgumentKeyConstants:
     FINAL = 'FINAL'
     DISABLE = 'DISABLE'
     LOGGING = 'LOGGING'
-    SILENT = 'SILENT'
+    YES = 'YES'
 
 
 class RegexConstants:

--- a/nttt/tidyup.py
+++ b/nttt/tidyup.py
@@ -99,7 +99,7 @@ def tidyup_translations(arguments):
             print(" - {}".format(os.path.relpath(file, input_folder)))
 
         continue_with_cleanup = True
-        if yes == 'off':
+        if yes != 'on':
             process_yn = input("Continue (y/n):")
             continue_with_cleanup = (process_yn.casefold() == "y")
 

--- a/nttt/tidyup.py
+++ b/nttt/tidyup.py
@@ -87,19 +87,19 @@ def tidyup_translations(arguments):
     logging = arguments[ArgumentKeyConstants.LOGGING]
     volunteers = arguments[ArgumentKeyConstants.VOLUNTEERS]
     final_step = arguments[ArgumentKeyConstants.FINAL]
-    silent = arguments[ArgumentKeyConstants.SILENT]
+    yes = arguments[ArgumentKeyConstants.YES]
 
     # get files to update
     print("Find files ...")
     files_to_update = find_files(input_folder, file_names=[GeneralConstants.FILE_NAME_META_YML], extensions=[".md"])
 
     if len(files_to_update) > 0:
-        continue_with_cleanup = True
-        if silent == 'off':
-            print("About to tidy up files:")
-            for file in files_to_update:
-                print(" - {}".format(os.path.relpath(file, input_folder)))
+        print("About to tidy up files:")
+        for file in files_to_update:
+            print(" - {}".format(os.path.relpath(file, input_folder)))
 
+        continue_with_cleanup = True
+        if yes == 'off':
             process_yn = input("Continue (y/n):")
             continue_with_cleanup = (process_yn.casefold() == "y")
 

--- a/unit_test/test_arguments.py
+++ b/unit_test/test_arguments.py
@@ -58,7 +58,7 @@ class TestArguments(unittest.TestCase):
                 self.final = False
                 self.Disable = False
                 self.Logging = False
-                self.Silent = False
+                self.Yes = False
 
         # Using the os.chdir function for a subdirectory of a directory created
         # with TemporaryDirectory doesn't work on Windows and macOS. Therefore,
@@ -84,7 +84,7 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.FINAL], 0)
         self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.DISABLE], [])
         self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.LOGGING], "off")
-        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.SILENT], "off")
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.YES], "off")
 
         input_folder = Path(data_folder, "da-DK")
         output_folder = Path(data_folder, "output")
@@ -100,7 +100,7 @@ class TestArguments(unittest.TestCase):
         command_line_args.final = 5
         command_line_args.Disable = "fix_md,fix_html"
         command_line_args.Logging = "on"
-        command_line_args.Silent = "on"
+        command_line_args.Yes = "on"
         arguments = nttt.arguments.resolve_arguments(command_line_args)
         self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.INPUT], input_folder)
         self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.OUTPUT], output_folder)
@@ -110,7 +110,7 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.FINAL], 5)
         self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.DISABLE], ["fix_md", "fix_html"])
         self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.LOGGING], "on")
-        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.SILENT], "on")
+        self.assertEqual(arguments[nttt.arguments.ArgumentKeyConstants.YES], "on")
 
     def test_check_folder(self):
         ''' Test case for the check_folder function:


### PR DESCRIPTION
This PR is another take on [#78](https://github.com/wheleph/nttt/pull/87)

There was an interesting [comment](https://github.com/wheleph/nttt/pull/87#issuecomment-1004114128) on https://github.com/wheleph/nttt/pull/87:
> Silent is fine, since it not only skips the Continue y/n question, but also doesn't print the files to be processed.

It made me think that the previous approach was not the best one.

1. While `--Silent on` in addition to preventing user prompts, does suppress some output, there's still plenty left, so it may be confusing to end-users. Here's an example:
```
/Users/wheleph/.asdf/installs/python/3.7.10/bin/python3 /Users/wheleph/pro/nttt/test/test_nttt.py -i "/Users/wheleph/pro/nttt-test-results/Boat race/l10n_master/hu-HU/" -e "/Users/wheleph/pro/nttt-test-results/Boat race/master/en" -L off -o /Users/wheleph/tmp/boat-race -S on
Input folder - '/Users/wheleph/pro/nttt-test-results/Boat race/l10n_master/hu-HU'
Output folder - '/Users/wheleph/tmp/boat-race'
English folder - '/Users/wheleph/pro/nttt-test-results/Boat race/master/en'
Language - 'hu-HU'
Volunteers - '[]'
Final step - '12'
Disabled functions - '[]'
Logging - 'off'
Silent - 'on'
Find files ...
Fixing - meta.yml
Fixing - step_1.md
Fixing - step_10.md
Fixing - step_11.md
Fixing - step_12.md
Fixing - step_2.md
Fixing - step_3.md
Fixing - step_4.md
Fixing - step_5.md
Fixing - step_6.md
Fixing - step_7.md
Fixing - step_8.md
Fixing - step_9.md
Adding volunteer acknowledgement - /Users/wheleph/tmp/boat-race/step_12.md
Warning: No volunteer name(s) given - please add them manually
Complete
```

2. Printing the list of files that will be scanned may be useful in both cases

The new proposal is to introduce `--Y`/`--Yes` switch with the possible values "on"/"off".

1. It's similar to the `-y` option in `apt-get` (https://linux.die.net/man/8/apt-get):
> -y, --yes, --assume-yes
> Automatic yes to prompts. Assume "yes" as answer to all prompts and run non-interactively. If an undesirable situation,  such as changing a held package or removing an essential package, occurs then apt-get will abort.

2. The name better reflects the purpose of the flag
3. In the future, we can reuse the value for any other prompts that may appear in NTTT

We use the capital `-Y` instead of `-y`. I don't remember if we discussed it or not, but looking at the existing flag names, I believe the convention is that _functional_ settings for NTTT start with small letters (`--input`, `--output`, `--english`, `--language`, `--volunteers`, `--final`) while _non-functional_ (`--Disable`, `--Logging`) start with capital ones